### PR TITLE
Drive use-octavia config from relation

### DIFF
--- a/lib/charms/layer/kubernetes_common.py
+++ b/lib/charms/layer/kubernetes_common.py
@@ -453,9 +453,14 @@ def generate_openstack_cloud_config():
     lines.extend([
         '',
         '[LoadBalancer]',
-        'use-octavia = true',
     ])
 
+    if openstack.has_octavia in (True, None):
+        # Newer integrator charm will detect whether underlying OpenStack has
+        # Octavia enabled so we can set this intelligently. If we're still
+        # related to an older integrator, though, default to assuming Octavia
+        # is available.
+        lines.append('use-octavia = true')
     if openstack.subnet_id:
         lines.append('subnet-id = {}'.format(openstack.subnet_id))
     if openstack.floating_network_id:


### PR DESCRIPTION
Add support for the integrator charm actually detecting whether Octavia is present and using that to drive the cloud provider config appropriately.

Depends on: https://github.com/juju-solutions/interface-openstack-integration/pull/11

Fixes https://bugs.launchpad.net/charm-kubernetes-master/+bug/1840421