### PR TITLE
Fix ca-file location in OS cloud config

### DIFF
--- a/lib/charms/layer/kubernetes_common.py
+++ b/lib/charms/layer/kubernetes_common.py
@@ -448,7 +448,7 @@ def generate_openstack_cloud_config():
         'domain-name = {}'.format(openstack.user_domain_name),
     ]
     if openstack.endpoint_tls_ca:
-        lines.append('ca-file = /etc/kubernetes/openstack-ca.cert')
+        lines.append('ca-file = /etc/config/endpoint-ca.cert')
 
     lines.extend([
         '',


### PR DESCRIPTION
The path of the Openstack CA cert file was incorrect in the cloud config
that gets passed to the Openstack Cloud Controller Manager.

The mountpoint should be /etc/config as defined in
https://github.com/kubernetes/cloud-provider-openstack/blob/master/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml#L31

The filename is defined in the cdk adons here:
https://github.com/charmed-kubernetes/cdk-addons/blob/6300b162e005267bdca22942ecaa06a37530cf37/get-addon-templates#L262