### PR TITLE
Correctly set project domain name

### DIFF
--- a/lib/charms/layer/kubernetes_common.py
+++ b/lib/charms/layer/kubernetes_common.py
@@ -483,7 +483,7 @@ def generate_openstack_cloud_config():
         'password = {}'.format(openstack.password),
         'tenant-name = {}'.format(openstack.project_name),
         'domain-name = {}'.format(openstack.user_domain_name),
-        'tenant-domain-name = {}'.format(openstack.project_domain_name)
+        'tenant-domain-name = {}'.format(openstack.project_domain_name),
     ]
     if openstack.endpoint_tls_ca:
         lines.append('ca-file = /etc/config/endpoint-ca.cert')

--- a/lib/charms/layer/kubernetes_common.py
+++ b/lib/charms/layer/kubernetes_common.py
@@ -483,6 +483,7 @@ def generate_openstack_cloud_config():
         'password = {}'.format(openstack.password),
         'tenant-name = {}'.format(openstack.project_name),
         'domain-name = {}'.format(openstack.user_domain_name),
+        'tenant-domain-name = {}'.format(openstack.project_domain_name)
     ]
     if openstack.endpoint_tls_ca:
         lines.append('ca-file = /etc/config/endpoint-ca.cert')


### PR DESCRIPTION
This PR correctly sets project domain name to make integration work
when user belongs to different domain than the project.

Fixes: https://bugs.launchpad.net/charm-kubernetes-master/+bug/1877148