### PR TITLE
Add fallback for get_networks(None)

### DIFF
--- a/lib/charms/layer/kubernetes_common.py
+++ b/lib/charms/layer/kubernetes_common.py
@@ -632,7 +632,7 @@ def is_ipv6_preferred(cidrs):
 
 def get_networks(cidrs):
     '''Convert a comma-separated list of CIDRs to a list of networks.'''
-    if cidrs is None:
+    if not cidrs:
         return []
     return [ipaddress.ip_interface(cidr).network for cidr in cidrs.split(',')]
 

--- a/lib/charms/layer/kubernetes_common.py
+++ b/lib/charms/layer/kubernetes_common.py
@@ -632,7 +632,8 @@ def is_ipv6_preferred(cidrs):
 
 def get_networks(cidrs):
     '''Convert a comma-separated list of CIDRs to a list of networks.'''
-    return [ipaddress.ip_interface(cidr).network for cidr in cidrs.split(',')]
+    return [ipaddress.ip_interface(cidr).network
+            for cidr in (cidrs or '').split(',')]
 
 
 def get_ipv4_network(cidrs):

--- a/lib/charms/layer/kubernetes_common.py
+++ b/lib/charms/layer/kubernetes_common.py
@@ -632,8 +632,9 @@ def is_ipv6_preferred(cidrs):
 
 def get_networks(cidrs):
     '''Convert a comma-separated list of CIDRs to a list of networks.'''
-    return [ipaddress.ip_interface(cidr).network
-            for cidr in (cidrs or '').split(',')]
+    if cidrs is None:
+        return []
+    return [ipaddress.ip_interface(cidr).network for cidr in cidrs.split(',')]
 
 
 def get_ipv4_network(cidrs):


### PR DESCRIPTION
Prevent `get_networks` from raising an exception if called with `None` instead of a CIDRs string. This can be triggered on edge cases where networks are checked before the CIDRs are available (i.e., from a relation).