### PR TITLE
Set use-octavia and lb-provider with Neutron LBaaS

### DIFF
--- a/lib/charms/layer/kubernetes_common.py
+++ b/lib/charms/layer/kubernetes_common.py
@@ -519,6 +519,9 @@ def generate_openstack_cloud_config():
         # related to an older integrator, though, default to assuming Octavia
         # is available.
         lines.append('use-octavia = true')
+    else:
+        lines.append('use-octavia = false')
+        lines.append('lb-provider = haproxy')
     if openstack.subnet_id:
         lines.append('subnet-id = {}'.format(openstack.subnet_id))
     if openstack.floating_network_id:


### PR DESCRIPTION
Last versions of Kubernetes set use-octavia=true and
lb-provider=amphora as the default values. This PR
explicitly sets use-octavia=false and lb-provider=haproxy
when the underlying OpenStack cloud relies on the old
Neutron LBaaS technology.

Closes-Bug: #1914295