### PR TITLE
Add logic path to disable Managed Identity

### DIFF
--- a/lib/charms/layer/kubernetes_common.py
+++ b/lib/charms/layer/kubernetes_common.py
@@ -605,7 +605,6 @@ def write_azure_snap_config(component):
                 "securityGroupName": azure.security_group_name,
                 "loadBalancerSku": "standard",
                 "securityGroupResourceGroup": azure.security_group_resource_group,
-                "loadBalancerSku": "standard",
                 "aadClientId": azure.aad_client_id,
                 "aadClientSecret": azure.aad_client_secret,
                 "tenantId": azure.tenant_id

--- a/lib/charms/layer/kubernetes_common.py
+++ b/lib/charms/layer/kubernetes_common.py
@@ -595,7 +595,7 @@ def write_azure_snap_config(component):
         json.dumps(
             {
                 "useInstanceMetadata": True,
-                "useManagedIdentityExtension": True,
+                "useManagedIdentityExtension": azure.managed_identity,
                 "subscriptionId": azure.subscription_id,
                 "resourceGroup": azure.resource_group,
                 "location": azure.resource_group_location,
@@ -604,6 +604,11 @@ def write_azure_snap_config(component):
                 "subnetName": azure.subnet_name,
                 "securityGroupName": azure.security_group_name,
                 "loadBalancerSku": "standard",
+                "securityGroupResourceGroup": azure.security_group_resource_group,
+                "loadBalancerSku": "standard",
+                "aadClientId": azure.aad_client_id,
+                "aadClientSecret": azure.aad_client_secret,
+                "tenantId": azure.tenant_id
             }
         )
     )

--- a/lib/charms/layer/kubernetes_common.py
+++ b/lib/charms/layer/kubernetes_common.py
@@ -607,7 +607,7 @@ def write_azure_snap_config(component):
                 "securityGroupResourceGroup": azure.security_group_resource_group,
                 "aadClientId": azure.aad_client_id,
                 "aadClientSecret": azure.aad_client_secret,
-                "tenantId": azure.tenant_id
+                "tenantId": azure.tenant_id,
             }
         )
     )


### PR DESCRIPTION
Managed Identity requires a "Owner" service principal to create and manage role assignments for the managed identities (VMs). This presents the problem of creating a service principal with such permissions.

Creating such application credentials present a security risk as if a malicious user were to gain access they could create accounts/create roles/assign roles/destroy the subscription (Virtual Datacentre) on azure.

This change mitigates this issue by enabling Charmed Kubernetes to use the service principal directly, instead of requiring a service principal with board permissions to assign roles.

Related [Azure integrator charm change](https://github.com/juju-solutions/charm-azure-integrator/pull/30)
Related [Interface change](https://github.com/juju-solutions/interface-azure-integration/pull/6)

Fixes [LP#1928906](https://bugs.launchpad.net/charm-azure-integrator/+bug/1928906)

- [x] Test disable managed identity path
- [x]  Test "credentials" file path
- [x]  Test juju grant path