### PR TITLE
Add auth secret functions so Calico can use them

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,8 @@ name: Test Suite
 on: [pull_request]
 
 jobs:
-  lint:
-    name: Lint
+  tests:
+    name: Lint, Unit, & Func Tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -19,42 +19,4 @@ jobs:
       run: |
         pip install tox
     - name: Run lint
-      run: tox -vve lint
-  unit-test:
-    name: Unit Tests
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python: [3.6, 3.7, 3.8, 3.9]
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Install Dependencies
-        run: |
-          pip install tox
-          sudo snap install kubectl --classic
-      - name: Run test
-        run: tox -vve unit
-  func-test:
-    name: Functional Tests
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python: [3.6, 3.7, 3.8, 3.9]
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Install Dependencies
-        run: |
-          pip install tox
-          sudo snap install kubectl --classic
-      - name: Run test
-        run: tox -vve functional
+      run: tox

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,25 @@ jobs:
         pip install tox
     - name: Run lint
       run: tox -vve lint
+  unit-test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: [3.6, 3.7, 3.8, 3.9]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install Dependencies
+        run: |
+          pip install tox
+          sudo snap install kubectl --classic
+      - name: Run test
+        run: tox -vve unit
   func-test:
     name: Functional Tests
     runs-on: ubuntu-latest

--- a/lib/charms/layer/kubernetes_common.py
+++ b/lib/charms/layer/kubernetes_common.py
@@ -21,7 +21,12 @@ import subprocess
 import hashlib
 import json
 import traceback
+import random
+import string
+import tempfile
+import yaml
 
+from base64 import b64decode, b64encode
 from pathlib import Path
 from subprocess import check_output, check_call
 from socket import gethostname, getfqdn
@@ -29,8 +34,12 @@ from shlex import split
 from subprocess import CalledProcessError
 from charmhelpers.core import hookenv, unitdata
 from charmhelpers.core import host
+from charmhelpers.core.templating import render
 from charms.reactive import endpoint_from_flag, is_state
 from time import sleep
+
+AUTH_SECRET_NS = "kube-system"
+AUTH_SECRET_TYPE = "juju.is/token-auth"
 
 db = unitdata.kv()
 kubeclientconfig_path = "/root/.kube/config"
@@ -762,3 +771,147 @@ def _get_vmware_uuid():
         uuid = "UNKNOWN"
 
     return uuid
+
+
+def token_generator(length=32):
+    """Generate a random token for use in account tokens.
+
+    param: length - the length of the token to generate
+    """
+    alpha = string.ascii_letters + string.digits
+    token = "".join(random.SystemRandom().choice(alpha) for _ in range(length))
+    return token
+
+
+def get_secret_names():
+    """Return a dict of 'username: secret_id' for Charmed Kubernetes users."""
+    try:
+        output = kubectl(
+            "get",
+            "secrets",
+            "-n",
+            AUTH_SECRET_NS,
+            "--field-selector",
+            "type={}".format(AUTH_SECRET_TYPE),
+            "-o",
+            "json",
+        ).decode("UTF-8")
+    except (CalledProcessError, FileNotFoundError):
+        # The api server may not be up, or we may be trying to run kubelet before
+        # the snap is installed. Send back an empty dict.
+        hookenv.log("Unable to get existing secrets", level=hookenv.WARNING)
+        return {}
+
+    secrets = json.loads(output)
+    secret_names = {}
+    if "items" in secrets:
+        for secret in secrets["items"]:
+            try:
+                secret_id = secret["metadata"]["name"]
+                username_b64 = secret["data"]["username"].encode("UTF-8")
+            except (KeyError, TypeError):
+                # CK secrets will have populated 'data', but not all secrets do
+                continue
+            secret_names[b64decode(username_b64).decode("UTF-8")] = secret_id
+    return secret_names
+
+
+def generate_rfc1123(length=10):
+    """Generate a random string compliant with RFC 1123.
+
+    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
+
+    param: length - the length of the string to generate
+    """
+    length = 253 if length > 253 else length
+    valid_chars = string.ascii_lowercase + string.digits
+    rand_str = "".join(random.SystemRandom().choice(valid_chars) for _ in range(length))
+    return rand_str
+
+
+def create_secret(token, username, user, groups=None):
+    secrets = get_secret_names()
+    if username in secrets:
+        # Use existing secret ID if one exists for our username
+        secret_id = secrets[username]
+    else:
+        # secret IDs must be unique and rfc1123 compliant
+        sani_name = re.sub("[^0-9a-z.-]+", "-", user.lower())
+        secret_id = "auth-{}-{}".format(sani_name, generate_rfc1123(10))
+
+    # The authenticator expects tokens to be in the form user::token
+    token_delim = "::"
+    if token_delim not in token:
+        token = "{}::{}".format(user, token)
+
+    context = {
+        "type": AUTH_SECRET_TYPE,
+        "secret_name": secret_id,
+        "secret_namespace": AUTH_SECRET_NS,
+        "user": b64encode(user.encode("UTF-8")).decode("utf-8"),
+        "username": b64encode(username.encode("UTF-8")).decode("utf-8"),
+        "password": b64encode(token.encode("UTF-8")).decode("utf-8"),
+        "groups": b64encode(groups.encode("UTF-8")).decode("utf-8") if groups else "",
+    }
+    with tempfile.NamedTemporaryFile() as tmp_manifest:
+        render(
+            "cdk.auth-webhook-secret.yaml", tmp_manifest.name, context=context
+        )
+
+        if kubectl_manifest("apply", tmp_manifest.name):
+            hookenv.log("Created secret for {}".format(username))
+            return True
+        else:
+            hookenv.log("WARN: Unable to create secret for {}".format(username))
+            return False
+
+
+def get_secret_password(username):
+    """Get the password for the given user from the secret that CK created."""
+    try:
+        output = kubectl(
+            "get",
+            "secrets",
+            "-n",
+            AUTH_SECRET_NS,
+            "--field-selector",
+            "type={}".format(AUTH_SECRET_TYPE),
+            "-o",
+            "json",
+        ).decode("UTF-8")
+    except CalledProcessError:
+        # NB: apiserver probably isn't up. This can happen on boostrap or upgrade
+        # while trying to build kubeconfig files. If we need the 'admin' token during
+        # this time, pull it directly out of the kubeconfig file if possible.
+        token = None
+        if username == "admin":
+            admin_kubeconfig = Path("/root/.kube/config")
+            if admin_kubeconfig.exists():
+                with admin_kubeconfig.open("r") as f:
+                    data = yaml.safe_load(f)
+                    try:
+                        token = data["users"][0]["user"]["token"]
+                    except (KeyError, ValueError):
+                        pass
+        return token
+    except FileNotFoundError:
+        # New deployments may ask for a token before the kubectl snap is installed.
+        # Give them nothing!
+        return None
+
+    secrets = json.loads(output)
+    if "items" in secrets:
+        for secret in secrets["items"]:
+            try:
+                data_b64 = secret["data"]
+                password_b64 = data_b64["password"].encode("UTF-8")
+                username_b64 = data_b64["username"].encode("UTF-8")
+            except (KeyError, TypeError):
+                # CK authn secrets will have populated 'data', but not all secrets do
+                continue
+
+            password = b64decode(password_b64).decode("UTF-8")
+            secret_user = b64decode(username_b64).decode("UTF-8")
+            if username == secret_user:
+                return password
+    return None

--- a/lib/charms/layer/kubernetes_common.py
+++ b/lib/charms/layer/kubernetes_common.py
@@ -887,12 +887,11 @@ def get_secret_password(username):
         if username == "admin":
             admin_kubeconfig = Path("/root/.kube/config")
             if admin_kubeconfig.exists():
-                with admin_kubeconfig.open("r") as f:
-                    data = yaml.safe_load(f)
-                    try:
-                        token = data["users"][0]["user"]["token"]
-                    except (KeyError, ValueError):
-                        pass
+                data = yaml.safe_load(admin_kubeconfig.read_text())
+                try:
+                    token = data["users"][0]["user"]["token"]
+                except (KeyError, IndexError, TypeError):
+                    pass
         return token
     except FileNotFoundError:
         # New deployments may ask for a token before the kubectl snap is installed.

--- a/lib/charms/layer/kubernetes_common.py
+++ b/lib/charms/layer/kubernetes_common.py
@@ -854,9 +854,7 @@ def create_secret(token, username, user, groups=None):
         "groups": b64encode(groups.encode("UTF-8")).decode("utf-8") if groups else "",
     }
     with tempfile.NamedTemporaryFile() as tmp_manifest:
-        render(
-            "cdk.auth-webhook-secret.yaml", tmp_manifest.name, context=context
-        )
+        render("cdk.auth-webhook-secret.yaml", tmp_manifest.name, context=context)
 
         if kubectl_manifest("apply", tmp_manifest.name):
             hookenv.log("Created secret for {}".format(username))

--- a/templates/cdk.auth-webhook-secret.yaml
+++ b/templates/cdk.auth-webhook-secret.yaml
@@ -1,0 +1,13 @@
+# Manifest for CK secrets that auth-webhook expects
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ secret_name }}
+  namespace: {{ secret_namespace }}
+type: {{ type }}
+data:
+  uid: {{ user }}
+  username: {{ username }}
+  password: {{ password }}
+  groups: '{{ groups }}'

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,4 @@
+import charms.unit_test
+
+
+charms.unit_test.patch_reactive()

--- a/tests/unit/test_k8s_common.py
+++ b/tests/unit/test_k8s_common.py
@@ -1,0 +1,122 @@
+import json
+import string
+from subprocess import CalledProcessError
+from unittest.mock import Mock
+
+from charms.layer import kubernetes_common as kc
+
+
+def test_token_generator():
+    alphanum = string.ascii_letters + string.digits
+    token = kc.token_generator(10)
+    assert len(token) == 10
+    unknown_chars = set(token) - set(alphanum)
+    assert not unknown_chars
+
+
+def test_get_secret_names(monkeypatch):
+    monkeypatch.setattr(kc, "kubectl", Mock())
+    kc.kubectl.side_effect = [
+        CalledProcessError(1, "none"),
+        FileNotFoundError,
+        "{}".encode("utf8"),
+        json.dumps(
+            {
+                "items": [
+                    {
+                        "metadata": {"name": "secret-id"},
+                        "data": {"username": "dXNlcg=="},
+                    },
+                ],
+            }
+        ).encode("utf8"),
+    ]
+    assert kc.get_secret_names() == {}
+    assert kc.get_secret_names() == {}
+    assert kc.get_secret_names() == {}
+    assert kc.get_secret_names() == {"user": "secret-id"}
+
+
+def test_generate_rfc1123():
+    alphanum = string.ascii_letters + string.digits
+    token = kc.generate_rfc1123(1000)
+    assert len(token) == 253
+    unknown_chars = set(token) - set(alphanum)
+    assert not unknown_chars
+
+
+def test_create_secret(monkeypatch):
+    monkeypatch.setattr(kc, "render", Mock())
+    monkeypatch.setattr(kc, "kubectl_manifest", Mock())
+    monkeypatch.setattr(kc, "get_secret_names", Mock())
+    monkeypatch.setattr(kc, "generate_rfc1123", Mock())
+    kc.kubectl_manifest.side_effect = [True, False]
+    kc.get_secret_names.side_effect = [{"username": "secret-id"}, {}]
+    kc.generate_rfc1123.return_value = "foo"
+    assert kc.create_secret("token", "username", "user", "groups")
+    assert kc.render.call_args[1]["context"] == {
+        "groups": "Z3JvdXBz",
+        "password": "dXNlcjo6dG9rZW4=",
+        "secret_name": "secret-id",
+        "secret_namespace": "kube-system",
+        "type": "juju.is/token-auth",
+        "user": "dXNlcg==",
+        "username": "dXNlcm5hbWU=",
+    }
+    assert not kc.create_secret("token", "username", "user", "groups")
+    assert kc.render.call_args[1]["context"] == {
+        "groups": "Z3JvdXBz",
+        "password": "dXNlcjo6dG9rZW4=",
+        "secret_name": "auth-user-foo",
+        "secret_namespace": "kube-system",
+        "type": "juju.is/token-auth",
+        "user": "dXNlcg==",
+        "username": "dXNlcm5hbWU=",
+    }
+
+
+def test_get_secret_password(monkeypatch):
+    monkeypatch.setattr(kc, "kubectl", Mock())
+    monkeypatch.setattr(kc, "Path", Mock())
+    monkeypatch.setattr(kc, "yaml", Mock())
+    kc.kubectl.side_effect = [
+        CalledProcessError(1, "none"),
+        CalledProcessError(1, "none"),
+        CalledProcessError(1, "none"),
+        CalledProcessError(1, "none"),
+        CalledProcessError(1, "none"),
+        CalledProcessError(1, "none"),
+        FileNotFoundError,
+        json.dumps({}).encode("utf8"),
+        json.dumps({"items": []}).encode("utf8"),
+        json.dumps({"items": []}).encode("utf8"),
+        json.dumps({"items": [{}]}).encode("utf8"),
+        json.dumps({"items": [{"data": {}}]}).encode("utf8"),
+        json.dumps(
+            {"items": [{"data": {"username": "Ym9i", "password": "c2VjcmV0"}}]}
+        ).encode("utf8"),
+        json.dumps(
+            {"items": [{"data": {"username": "dXNlcm5hbWU=", "password": "c2VjcmV0"}}]}
+        ).encode("utf8"),
+    ]
+    kc.yaml.safe_load.side_effect = [
+        {},
+        {"users": None},
+        {"users": []},
+        {"users": [{"user": {}}]},
+        {"users": [{"user": {"token": "secret"}}]},
+    ]
+    assert kc.get_secret_password("username") is None
+    assert kc.get_secret_password("admin") is None
+    assert kc.get_secret_password("admin") is None
+    assert kc.get_secret_password("admin") is None
+    assert kc.get_secret_password("admin") is None
+    assert kc.get_secret_password("admin") == "secret"
+    assert kc.get_secret_password("username") is None
+    assert kc.get_secret_password("username") is None
+    assert kc.get_secret_password("username") is None
+    assert kc.get_secret_password("username") is None
+    assert kc.get_secret_password("username") is None
+    assert kc.get_secret_password("username") is None
+    assert kc.get_secret_password("username") is None
+    assert kc.get_secret_password("username") == "secret"

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ max-line-length = 88
 
 [tox]
 skipsdist = True
-envlist = lint,functional
+envlist = lint,unit,functional
 
 [testenv]
 setenv =
@@ -18,10 +18,18 @@ commands =
     flake8 {toxinidir}/lib {toxinidir}/tests
     black --check {toxinidir}/lib {toxinidir}/tests
 
+[testenv:unit]
+deps =
+    pyyaml
+    pytest
+    charms.unit_test
+    ipdb
+commands = pytest -vv --tb native -s {posargs} {toxinidir}/tests/unit
+
 [testenv:functional]
 deps =
     pyyaml
     pytest
     charms.unit_test
     ipdb
-commands = pytest --tb native -s {posargs} {toxinidir}/tests/functional
+commands = pytest -vv --tb native -s {posargs} {toxinidir}/tests/functional


### PR DESCRIPTION
https://bugs.launchpad.net/charm-calico/+bug/1920034

For Calico BGP service IP support, the Calico charm needs to be able to create a system:calico-node user for the calico-node service to use. The charm has admin access to the Kubernetes API, so the idea is to pull the auth secret functions from charm-kubernetes-master into layer-kubernetes-common so that the Calico charm can create its own user.

~~Marked as draft PR. Tests needed.~~ Ready for review and merge.