### PR TITLE
Extend get_ingress_address() to discard certain IP addresses.

### DIFF
--- a/lib/charms/layer/kubernetes_common.py
+++ b/lib/charms/layer/kubernetes_common.py
@@ -159,7 +159,7 @@ def calculate_and_store_resource_checksums(checksum_prefix, snap_resources):
         db.set(key, checksum)
 
 
-def get_ingress_address(endpoint_name):
+def get_ingress_address(endpoint_name, ignore_addresses=None):
     try:
         network_info = hookenv.network_get(endpoint_name)
     except NotImplementedError:
@@ -171,6 +171,12 @@ def get_ingress_address(endpoint_name):
         return hookenv.unit_get("private-address")
 
     addresses = network_info["ingress-addresses"]
+
+    if ignore_addresses:
+        hookenv.log("ingress-addresses before filtering: {}".format(addresses))
+        iter_filter = filter(lambda item: item not in ignore_addresses, addresses)
+        addresses = list(iter_filter)
+        hookenv.log("ingress-addresses after filtering: {}".format(addresses))
 
     # Need to prefer non-fan IP addresses due to various issues, e.g.
     # https://bugs.launchpad.net/charm-gcp-integrator/+bug/1822997

--- a/tests/functional/test_k8s_common.py
+++ b/tests/functional/test_k8s_common.py
@@ -1,7 +1,7 @@
 from functools import partial
 
 import pytest
-
+from unittest import mock
 from charms.layer import kubernetes_common
 
 
@@ -80,3 +80,11 @@ class TestCreateKubeConfig:
         assert cfg_data_1 != cfg_data_2
         assert "old_password" in cfg_data_1
         assert "new_password" in cfg_data_2
+
+    @mock.patch("charmhelpers.core.hookenv.network_get", autospec=True)
+    def test_get_ingress_address(self, network_get):
+        network_get.return_value = {"ingress-addresses": ["1.2.3.4", "5.6.7.8"]}
+        ingress = kubernetes_common.get_ingress_address("endpoint-name")
+        assert ingress == "1.2.3.4"
+        ingress = kubernetes_common.get_ingress_address("endpoint-name", ["1.2.3.4"])
+        assert ingress == "5.6.7.8"


### PR DESCRIPTION
This patch adds a parameter to get_ingress_address() named
ignore_addresses that when passed those IP addresses won't be
considered in the list of possible values to return.

Related-Bug: [lp:1925382](https://bugs.launchpad.net/bugs/1925382)