### PR TITLE
fix obtain ingress address

### DIFF
--- a/lib/charms/layer/kubernetes_common.py
+++ b/lib/charms/layer/kubernetes_common.py
@@ -172,7 +172,7 @@ def get_ingress_address(endpoint_name, ignore_addresses=None):
 
     addresses = []
     ignore_interfaces = ("lxdbr", "flannel", "cni", "virbr", "docker", "cali", "kube-ipvs")
-    for interface in temp['bind-addresses']:
+    for interface in network_info['bind-addresses']:
         if any (
             interface['interfacename'].startswith(prefix) for prefix in ignore_interfaces
         ):

--- a/lib/charms/layer/kubernetes_common.py
+++ b/lib/charms/layer/kubernetes_common.py
@@ -170,7 +170,16 @@ def get_ingress_address(endpoint_name, ignore_addresses=None):
         # doesn't support spaces, so just return the private address
         return hookenv.unit_get("private-address")
 
-    addresses = network_info["ingress-addresses"]
+    addresses = []
+    ignore_interfaces = ("lxdbr", "flannel", "cni", "virbr", "docker", "cali", "kube-ipvs")
+    for interface in temp['bind-addresses']:
+        if any (
+            interface['interfacename'].startswith(prefix) for prefix in ignore_interfaces
+        ):
+            continue
+        for addr in interface['addresses']:
+            if '32' not in addr['cidr']:
+                addresses.append(addr['address'])
 
     if ignore_addresses:
         hookenv.log("ingress-addresses before filtering: {}".format(addresses))

--- a/lib/charms/layer/kubernetes_common.py
+++ b/lib/charms/layer/kubernetes_common.py
@@ -179,7 +179,7 @@ def get_ingress_address(endpoint_name, ignore_addresses=None):
         ):
             continue
         for addr in interface['addresses']:
-            if '32' not in addr['cidr']:
+            if '/32' not in addr['cidr']:
                 addresses.append(addr['address'])
 
     if ignore_addresses:


### PR DESCRIPTION
We Should to ignore some virtual interface.

In some slow network，some node always get the wrong ip address for kube-api & kube-proxy

https://bugs.launchpad.net/charm-kubernetes-master/+bug/1956291