### PR TITLE
bump pause image to 3.6

### DIFF
--- a/lib/charms/layer/kubernetes_common.py
+++ b/lib/charms/layer/kubernetes_common.py
@@ -993,7 +993,7 @@ def workaround_lxd_kernel_params():
 
 
 def get_sandbox_image_uri(registry):
-    return "{}/pause:3.4.1".format(registry)
+    return "{}/pause:3.6".format(registry)
 
 
 def configure_kubelet(dns_domain, dns_ip, registry, taints=None, has_xcp=False):


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charmed-kubernetes-bundles/+bug/1965825

Update pause image to match upstream and the containerd subordinate charm.  Depends on https://github.com/charmed-kubernetes/bundle/pull/826 to get pause:3.6 into rocks first.