### PR TITLE
Add internal-lb option

### DIFF
--- a/lib/charms/layer/kubernetes_common.py
+++ b/lib/charms/layer/kubernetes_common.py
@@ -586,6 +586,8 @@ def generate_openstack_cloud_config():
         lines.append("floating-network-id = {}".format(openstack.floating_network_id))
     if openstack.lb_method:
         lines.append("lb-method = {}".format(openstack.lb_method))
+    if openstack.internal_lb:
+        lines.append("internal-lb = true")
     if openstack.manage_security_groups:
         lines.append(
             "manage-security-groups = {}".format(openstack.manage_security_groups)


### PR DESCRIPTION
This reads the value from the openstack integrator interface,
and templates it out to the config file for cloud-provider-openstack.

Related PRs:
- https://github.com/juju-solutions/interface-openstack-integration/pull/12
- https://github.com/juju-solutions/charm-openstack-integrator/pull/60

Launchpad bug: [#1877692](https://bugs.launchpad.net/charm-openstack-integrator/+bug/1877692)