### PR TITLE
delay kubectl calls when required subs are departing

### DIFF
--- a/lib/charms/layer/kubernetes_common.py
+++ b/lib/charms/layer/kubernetes_common.py
@@ -246,9 +246,11 @@ def get_service_ip(service, namespace="kube-system", errors_fatal=True):
             raise
         else:
             return None
-    else:
+    if output:
         svc = json.loads(output.decode())
         return svc["spec"]["clusterIP"]
+    else:
+        return None
 
 
 def kubectl(*args):
@@ -256,15 +258,20 @@ def kubectl(*args):
     an error if the command fails."""
     command = ["kubectl", "--kubeconfig=" + kubeclientconfig_path] + list(args)
     hookenv.log("Executing {}".format(command))
-    return check_output(command)
+    if is_state("endpoint.cni.departed") or is_state(
+        "endpoint.container-runtime.departed"
+    ):
+        hookenv.log("Required subordinates are departing; delaying kubectl")
+        return b""
+    else:
+        return check_output(command)
 
 
 def kubectl_success(*args):
     """Runs kubectl with the given args. Returns True if successful, False if
     not."""
     try:
-        kubectl(*args)
-        return True
+        return True if kubectl(*args) else False
     except CalledProcessError:
         return False
 
@@ -824,7 +831,7 @@ def get_secret_names():
         hookenv.log("Unable to get existing secrets", level=hookenv.WARNING)
         return {}
 
-    secrets = json.loads(output)
+    secrets = json.loads(output) if output else {}
     secret_names = {}
     if "items" in secrets:
         for secret in secrets["items"]:
@@ -918,7 +925,7 @@ def get_secret_password(username):
         # Give them nothing!
         return None
 
-    secrets = json.loads(output)
+    secrets = json.loads(output) if output else {}
     if "items" in secrets:
         for secret in secrets["items"]:
             try:


### PR DESCRIPTION
When we know required subordinate charms are going away, don't run `kubectl` commands -- they take forever to time out.

Fixes https://bugs.launchpad.net/charm-kubernetes-master/+bug/1968237

Depends on https://github.com/charmed-kubernetes/charm-kubernetes-control-plane/pull/214