### PR TITLE
Fix default-cni config for kube-ovn

### DIFF
--- a/lib/charms/layer/kubernetes_common.py
+++ b/lib/charms/layer/kubernetes_common.py
@@ -1115,21 +1115,21 @@ def configure_default_cni(default_cni):
 
     CNI clients choose whichever CNI config in /etc/cni/net.d/ is
     alphabetically first, so we accomplish this by creating a file named
-    /etc/cni/net.d/05-default.conflist, which is alphabetically earlier than
+    /etc/cni/net.d/01-default.conflist, which is alphabetically earlier than
     typical CNI config names, e.g. 10-flannel.conflist and 10-calico.conflist
 
-    The created 05-default.conflist file is a symlink to whichever CNI config
+    The created 01-default.conflist file is a symlink to whichever CNI config
     is actually going to be used.
     """
     # Clean up current default
     cni_conf_dir = "/etc/cni/net.d"
     for filename in os.listdir(cni_conf_dir):
-        if filename.startswith("05-default."):
+        if filename.startswith("01-default."):
             os.remove(cni_conf_dir + "/" + filename)
 
     # Set new default
     cni = endpoint_from_flag("cni.available")
     cni_conf = cni.get_config(default=default_cni)
     source = cni_conf["cni-conf-file"]
-    dest = cni_conf_dir + "/" + "05-default." + source.split(".")[-1]
+    dest = cni_conf_dir + "/" + "01-default." + source.split(".")[-1]
     os.symlink(source, dest)

--- a/tests/unit/test_k8s_common.py
+++ b/tests/unit/test_k8s_common.py
@@ -127,14 +127,14 @@ def test_get_secret_password(monkeypatch):
 @patch("os.remove")
 @patch("os.symlink")
 def test_configure_default_cni(os_symlink, os_remove, os_listdir):
-    os_listdir.return_value = ["05-default.conflist", "10-cni.conflist"]
+    os_listdir.return_value = ["01-default.conflist", "10-cni.conflist"]
     cni = endpoint_from_flag("cni.available")
     cni.get_config.return_value = {
         "cidr": "192.168.0.0/24",
         "cni-conf-file": "10-cni.conflist",
     }
     kc.configure_default_cni("test-cni")
-    os_remove.assert_called_once_with("/etc/cni/net.d/05-default.conflist")
+    os_remove.assert_called_once_with("/etc/cni/net.d/01-default.conflist")
     os_symlink.assert_called_once_with(
-        "10-cni.conflist", "/etc/cni/net.d/05-default.conflist"
+        "10-cni.conflist", "/etc/cni/net.d/01-default.conflist"
     )


### PR DESCRIPTION
Fix default-cni config not working with kube-ovn.

The CNI config created by kube-ovn is `01-kube-ovn.conflist`, which is higher priority than the `05-default.conflist` symlink we create. So the default symlink will be ignored.

Fix it by renaming the symlink to `01-default.conflist`, which is alphabetically earlier than `01-kube-ovn.conflist` and therefore higher priority.