### PR TITLE
Remove IPv6DualStack feature gate

### DIFF
--- a/lib/charms/layer/kubernetes_common.py
+++ b/lib/charms/layer/kubernetes_common.py
@@ -652,9 +652,6 @@ def configure_kube_proxy(
 
     feature_gates = []
 
-    if is_dual_stack(cluster_cidr):
-        feature_gates.append("IPv6DualStack=true")
-
     if is_state("endpoint.aws.ready"):
         if get_version("kubelet") < (1, 25, 0):
             feature_gates.append("CSIMigrationAWS=false")
@@ -1084,9 +1081,6 @@ def configure_kubelet(dns_domain, dns_ip, registry, taints=None, has_xcp=False):
         feature_gates["DevicePlugins"] = True
     if feature_gates:
         kubelet_config["featureGates"] = feature_gates
-    if is_dual_stack(cluster_cidr()):
-        feature_gates = kubelet_config.setdefault("featureGates", {})
-        feature_gates["IPv6DualStack"] = True
 
     # Workaround for DNS on bionic
     # https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/655


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/bugs/1990455

The IPv6DualStack feature gate was removed in k8s 1.25 ([source](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md#other-cleanup-or-flake)). Setting the feature gate now causes k8s services to fail.

This feature has been enabled by default since k8s 1.21 and GA since k8s 1.23 ([source](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/)) so we shouldn't need to worry about backwards compatibility with this change.