### PR TITLE
Add add_systemd_restart_always to common layer

### DIFF
--- a/templates/service-always-restart.systemd-229.conf
+++ b/templates/service-always-restart.systemd-229.conf
@@ -1,0 +1,5 @@
+[Unit]
+StartLimitInterval=0
+
+[Service]
+RestartSec=10

--- a/templates/service-always-restart.systemd-latest.conf
+++ b/templates/service-always-restart.systemd-latest.conf
@@ -1,0 +1,5 @@
+[Unit]
+StartLimitIntervalSec=0
+
+[Service]
+RestartSec=10


### PR DESCRIPTION
Partial fix for https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1999419

This code is moved from kubernetes-control-plane to kubernetes-common, so that kubernetes-worker can use it too.