### PR TITLE
Add support for lb_enabled from the openstack relation

### DIFF
--- a/lib/charms/layer/kubernetes_common.py
+++ b/lib/charms/layer/kubernetes_common.py
@@ -572,7 +572,7 @@ def generate_openstack_cloud_config():
         ]
     )
 
-    if openstack.lb_enabled == False:
+    if openstack.lb_enabled is False:
         lines.append("enabled = false")
 
     if openstack.has_octavia in (True, None):

--- a/lib/charms/layer/kubernetes_common.py
+++ b/lib/charms/layer/kubernetes_common.py
@@ -572,6 +572,9 @@ def generate_openstack_cloud_config():
         ]
     )
 
+    if openstack.lb_enabled == False:
+        lines.append("enabled = false")
+
     if openstack.has_octavia in (True, None):
         # Newer integrator charm will detect whether underlying OpenStack has
         # Octavia enabled so we can set this intelligently. If we're still


### PR DESCRIPTION
Partial fix for https://bugs.launchpad.net/bugs/1995746 and https://bugs.launchpad.net/bugs/1990494
Depends on https://github.com/juju-solutions/interface-openstack-integration/pull/13

If lb_enabled is set to false on the openstack-integration relation, then disable LoadBalancer support in openstack-cloud-controller-manager config.

Thanks to @nikolayvinogradov for the initial work on this!