### PR TITLE
Remove DevicePlugins from feature_gate on 1.28+

### DIFF
--- a/lib/charms/layer/kubernetes_common.py
+++ b/lib/charms/layer/kubernetes_common.py
@@ -1169,7 +1169,7 @@ def configure_kubelet(
     if kube_version >= (1, 19):
         # NB: required for CIS compliance
         feature_gates["RotateKubeletServerCertificate"] = True
-    if is_state("kubernetes-worker.gpu.enabled"):
+    if is_state("kubernetes-worker.gpu.enabled") and kube_version <= (1, 27, 0):
         feature_gates["DevicePlugins"] = True
     if feature_gates:
         kubelet_config["featureGates"] = feature_gates

--- a/lib/charms/layer/kubernetes_common.py
+++ b/lib/charms/layer/kubernetes_common.py
@@ -1169,7 +1169,7 @@ def configure_kubelet(
     if kube_version >= (1, 19):
         # NB: required for CIS compliance
         feature_gates["RotateKubeletServerCertificate"] = True
-    if is_state("kubernetes-worker.gpu.enabled") and kube_version <= (1, 27, 0):
+    if is_state("kubernetes-worker.gpu.enabled") and kube_version < (1, 28):
         feature_gates["DevicePlugins"] = True
     if feature_gates:
         kubelet_config["featureGates"] = feature_gates


### PR DESCRIPTION
DevicePlugins was removed from behind a feature gate starting with 1.28. This PR will remove it from kubelet config on 1.28+

Fixes: [LP#2038970](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2038970)